### PR TITLE
Bump mcaf workspace to v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## Unreleased
 
+## 1.2.0 (2022-01-14)
+### Changed
+* Bumped mcaf workspace to to v0.7.0.
+
 ## 1.1.0 (2021-12-29)
 ### Changed
-* Bumped mcaf account to v0.5.0 and removed "create_email_address" from account settings. 
+* Bumped mcaf account to v0.5.0 and removed "create_email_address" from account settings.
 
 ## 1.0.0 (2021-11-16)
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ module "aws_account" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_account"></a> [account](#module\_account) | github.com/schubergphilis/terraform-aws-mcaf-account | v0.5.0 |
-| <a name="module_additional_tfe_workspaces"></a> [additional\_tfe\_workspaces](#module\_additional\_tfe\_workspaces) | github.com/schubergphilis/terraform-aws-mcaf-workspace | v0.6.0 |
-| <a name="module_tfe_workspace"></a> [tfe\_workspace](#module\_tfe\_workspace) | github.com/schubergphilis/terraform-aws-mcaf-workspace | v0.6.0 |
+| <a name="module_additional_tfe_workspaces"></a> [additional\_tfe\_workspaces](#module\_additional\_tfe\_workspaces) | github.com/schubergphilis/terraform-aws-mcaf-workspace | v0.7.0 |
+| <a name="module_tfe_workspace"></a> [tfe\_workspace](#module\_tfe\_workspace) | github.com/schubergphilis/terraform-aws-mcaf-workspace | v0.7.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ module "account" {
 
 module "tfe_workspace" {
   count                         = var.tfe_workspace_settings != null ? 1 : 0
-  source                        = "github.com/schubergphilis/terraform-aws-mcaf-workspace?ref=v0.6.0"
+  source                        = "github.com/schubergphilis/terraform-aws-mcaf-workspace?ref=v0.7.0"
   providers                     = { aws = aws.account }
   name                          = coalesce(var.tfe_workspace_name, var.name)
   agent_pool_id                 = var.tfe_workspace_agent_pool_id
@@ -62,7 +62,7 @@ module "tfe_workspace" {
 
 module "additional_tfe_workspaces" {
   for_each                      = var.additional_tfe_workspaces
-  source                        = "github.com/schubergphilis/terraform-aws-mcaf-workspace?ref=v0.6.0"
+  source                        = "github.com/schubergphilis/terraform-aws-mcaf-workspace?ref=v0.7.0"
   providers                     = { aws = aws.account }
   name                          = each.key
   agent_pool_id                 = each.value.agent_pool_id


### PR DESCRIPTION
This PR bumps the version of MCAF AWS workspace to 0.7.0.