### PR TITLE
Inherit more from `var.tfe_workspace`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ ENHANCEMENTS
 - Bumped [terraform-aws-mcaf-account](https://github.com/schubergphilis/terraform-aws-mcaf-account) module to v0.5.1: Adds support to specify an OU path to provision an account into a nested OU ([#23](https://github.com/schubergphilis/terraform-aws-mcaf-avm/pull/23))
 - Modify variables to optional variables in the `additional_tfe_workspaces` and `tfe_workspace_settings` variable and add support for setting the workspace team access ([#22](https://github.com/schubergphilis/terraform-aws-mcaf-avm/pull/22))
 - Bumped [terraform-aws-mcaf-workspace](https://github.com/schubergphilis/terraform-aws-mcaf-workspace) to v0.9.0 to support using IAM roles as a way for workspaces to authenticate to AWS (instead of creating an IAM user) ([#21](https://github.com/schubergphilis/terraform-aws-mcaf-avm/pull/21))
+- Inherit more from `var.tfe_workspace` ([#26](https://github.com/schubergphilis/terraform-aws-mcaf-avm/pull/26))
 
 ## 1.2.1 (2022-01-27)
 

--- a/main.tf
+++ b/main.tf
@@ -74,8 +74,8 @@ module "additional_tfe_workspaces" {
   source    = "github.com/schubergphilis/terraform-aws-mcaf-workspace?ref=v0.9.0"
   providers = { aws = aws.account }
 
-  agent_pool_id                  = each.value.agent_pool_id
-  agent_role_arn                 = each.value.agent_role_arn
+  agent_pool_id                  = each.value.agent_pool_id != null ? each.value.agent_pool_id : var.tfe_workspace.agent_pool_id
+  agent_role_arn                 = each.value.agent_role_arn != null ? each.value.agent_role_arn : var.tfe_workspace.agent_role_arn
   auth_method                    = each.value.auth_method != null ? each.value.auth_method : var.tfe_workspace.auth_method
   auto_apply                     = each.value.auto_apply
   branch                         = coalesce(each.value.branch, var.tfe_workspace.branch)
@@ -91,7 +91,7 @@ module "additional_tfe_workspaces" {
   policy_arns                    = each.value.policy_arns
   region                         = coalesce(each.value.default_region, var.tfe_workspace.default_region)
   remote_state_consumer_ids      = each.value.remote_state_consumer_ids
-  repository_identifier          = try(each.value.repository_identifier, var.tfe_workspace.repository_identifier)
+  repository_identifier          = coalesce(each.value.repository_identifier, var.tfe_workspace.repository_identifier)
   role_name                      = coalesce(each.value.role_name, "TFEPipeline-${each.key}")
   sensitive_env_variables        = each.value.sensitive_env_variables
   sensitive_hcl_variables        = each.value.sensitive_hcl_variables


### PR DESCRIPTION
When using additional workspaces they are likely to use the same settings as the default workspace (set in `var.tfe_settings`), so rather than set these values again we should inherit them from `var.tfe_settings`:

* `agent_pool_id`
* `agent_role_arn`
* `repository_identifier`

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
