### PR TITLE
Fix clear_text_terraform_variables in additional workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.1 (2023-01-11)
+
+BUG FIXES
+
+- Fix `clear_text_terraform_variables` in additional workspaces ([#32](https://github.com/schubergphilis/terraform-aws-mcaf-avm/pull/32))
+
 ## 2.1.0 (2023-01-03)
 
 - Bumped [terraform-aws-mcaf-workspace](https://github.com/schubergphilis/terraform-aws-mcaf-workspace) module to v0.10.0: Adds support to use custom workspace permissions ([#29](https://github.com/schubergphilis/terraform-aws-mcaf-avm/pull/29))

--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ module "additional_tfe_workspaces" {
   branch                         = coalesce(each.value.branch, var.tfe_workspace.branch)
   clear_text_env_variables       = each.value.clear_text_env_variables
   clear_text_hcl_variables       = each.value.clear_text_hcl_variables
-  clear_text_terraform_variables = merge(local.tfe_workspace.clear_text_terraform_variables, var.tfe_workspace.clear_text_terraform_variables)
+  clear_text_terraform_variables = merge(local.tfe_workspace.clear_text_terraform_variables, each.value.clear_text_terraform_variables)
   execution_mode                 = coalesce(each.value.execution_mode, var.tfe_workspace.execution_mode)
   file_triggers_enabled          = each.value.file_triggers_enabled
   global_remote_state            = each.value.global_remote_state


### PR DESCRIPTION
This was copied from the `tfe_workspace` variable and not updated to use the `clear_text_terraform_variables` value in the `for_each` loop, so any clear text variables for an additional workspace were not being created.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
