### PR TITLE
feat: optional repo identifier for TFE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# 2.7.2 (2023-04-13)
+
+- Changed repository_identifier variable to optional and changed the corresponding coalesce into a try. This way, teams who don't need additional tfe workspaces repositories for additional workspaces can proceed with updating.
+
 # 2.7.1 (2023-02-15)
 
 - Add default_tags to provider configuration. ([#39] https://github.com/schubergphilis/terraform-aws-mcaf-avm/pull/39))

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ module "additional_tfe_workspaces" {
   project_id                     = each.value.project_id != null ? each.value.project_id : var.tfe_workspace.project_id
   region                         = coalesce(each.value.default_region, var.tfe_workspace.default_region)
   remote_state_consumer_ids      = each.value.remote_state_consumer_ids
-  repository_identifier          = coalesce(each.value.repository_identifier, var.tfe_workspace.repository_identifier)
+  repository_identifier          = try(each.value.repository_identifier, var.tfe_workspace.repository_identifier)
   role_name                      = coalesce(each.value.role_name, "TFEPipeline${replace(title(each.key), "/[_-]/", "")}")
   sensitive_env_variables        = each.value.sensitive_env_variables
   sensitive_hcl_variables        = each.value.sensitive_hcl_variables

--- a/variables.tf
+++ b/variables.tf
@@ -130,7 +130,7 @@ variable "tfe_workspace" {
     policy_arns                    = optional(list(string), ["arn:aws:iam::aws:policy/AdministratorAccess"])
     project_id                     = optional(string, null)
     remote_state_consumer_ids      = optional(set(string))
-    repository_identifier          = string
+    repository_identifier          = optional(string, null)
     role_name                      = optional(string, "TFEPipeline")
     sensitive_env_variables        = optional(map(string), {})
     sensitive_hcl_variables        = optional(map(object({ sensitive = string })), {})


### PR DESCRIPTION
GMT team doesn't require a repository identifier as not all additional accounts require a TFE workspace. When entering null in the code, the plan fails due to the coalesce. This is why the coalesce is rebuild to a try