### PR TITLE
feat: do not set certain vcs related values when `connect_vcs_repo` has been set to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ module "additional_tfe_workspaces" {
   team_access                    = each.value.team_access != {} ? each.value.team_access : var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
   terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.tfe_workspace.terraform_version
-  trigger_prefixes               = each.value.connect_vcs_repo != false ? each.value.trigger_prefixes : var.tfe_workspace.trigger_prefixes
+  trigger_prefixes               = each.value.connect_vcs_repo != false ? each.value.trigger_prefixes : null
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
   working_directory              = each.value.connect_vcs_repo != false ? each.value.working_directory : "terraform/${coalesce(each.value.name, each.key)}"
 }

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ module "additional_tfe_workspaces" {
   team_access                    = each.value.team_access != {} ? each.value.team_access : var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
   terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.additional_tfe_workspace.terraform_version
-  trigger_prefixes               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_prefixes, var.tfe_workspaces.trigger_prefixes) : null
+  trigger_prefixes               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_prefixes, var.tfe_workspace.trigger_prefixes) : null
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
   working_directory              = each.value.connect_vcs_repo != false ? coalesce(each.value.working_directory, "terraform/${coalesce(each.value.name, each.key)}") : null
 }

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ module "tfe_workspace" {
   agent_role_arns                = var.tfe_workspace.agent_role_arns
   auth_method                    = var.tfe_workspace.auth_method
   auto_apply                     = var.tfe_workspace.auto_apply
-  branch                         = var.tfe_workspace.connect_vcs_repo ? var.tfe_workspace.branch : null
+  branch                         = var.tfe_workspace.connect_vcs_repo != false ? var.tfe_workspace.branch : null
   clear_text_env_variables       = var.tfe_workspace.clear_text_env_variables
   clear_text_hcl_variables       = var.tfe_workspace.clear_text_hcl_variables
   clear_text_terraform_variables = merge(local.tfe_workspace.clear_text_terraform_variables, var.tfe_workspace.clear_text_terraform_variables)
@@ -79,7 +79,7 @@ module "tfe_workspace" {
   project_id                     = var.tfe_workspace.project_id
   region                         = var.tfe_workspace.default_region
   remote_state_consumer_ids      = var.tfe_workspace.remote_state_consumer_ids
-  repository_identifier          = var.tfe_workspace.connect_vcs_repo ? var.tfe_workspace.repository_identifier : null
+  repository_identifier          = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.connect_vcs_repo, var.tfe_workspace.repository_identifier) : null
   role_name                      = var.tfe_workspace.role_name
   sensitive_env_variables        = var.tfe_workspace.sensitive_env_variables
   sensitive_hcl_variables        = var.tfe_workspace.sensitive_hcl_variables
@@ -119,7 +119,7 @@ module "additional_tfe_workspaces" {
   policy_arns                    = each.value.policy_arns
   project_id                     = each.value.project_id != null ? each.value.project_id : var.tfe_workspace.project_id
   region                         = coalesce(each.value.default_region, var.tfe_workspace.default_region)
-  remote_state_consumer_ids      = each.value.remote_state_consumer_ids
+  remote_state_consumer_ids      = each.value.connect_vcs_repo != false ? each.value.remote_state_consumer_ids : null
   repository_identifier          = each.value.connect_vcs_repo != false ? coalesce(each.value.repository_identifier, var.tfe_workspace.repository_identifier) : null
   role_name                      = coalesce(each.value.role_name, "TFEPipeline${replace(title(each.key), "/[_-]/", "")}")
   sensitive_env_variables        = each.value.sensitive_env_variables

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "tfe_workspace" {
   team_access                    = var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
   terraform_version              = var.tfe_workspace.terraform_version
-  trigger_prefixes               = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.trigger_prefixes, ["modules"]) : null
+  trigger_prefixes               = var.tfe_workspace.connect_vcs_repo != false ? var.tfe_workspace.trigger_prefixes : null
   username                       = var.tfe_workspace.username
   working_directory              = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.working_directory, local.tfe_workspace.working_directory) : null
 }

--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,7 @@ module "additional_tfe_workspaces" {
   ssh_key_id                     = each.value.ssh_key_id != null ? each.value.ssh_key_id : var.tfe_workspace.ssh_key_id
   team_access                    = each.value.team_access != {} ? each.value.team_access : var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
-  terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.additional_tfe_workspace.terraform_version
+  terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.tfe_workspace.terraform_version
   trigger_prefixes               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_prefixes, var.tfe_workspace.trigger_prefixes) : null
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
   working_directory              = each.value.connect_vcs_repo != false ? coalesce(each.value.working_directory, "terraform/${coalesce(each.value.name, each.key)}") : null

--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,7 @@ module "additional_tfe_workspaces" {
   policy_arns                    = each.value.policy_arns
   project_id                     = each.value.project_id != null ? each.value.project_id : var.tfe_workspace.project_id
   region                         = coalesce(each.value.default_region, var.tfe_workspace.default_region)
-  remote_state_consumer_ids      = each.value.connect_vcs_repo != false ? each.value.remote_state_consumer_ids : null
+  remote_state_consumer_ids      = each.value.remote_state_consumer_ids
   repository_identifier          = each.value.connect_vcs_repo != false ? coalesce(each.value.repository_identifier, var.tfe_workspace.repository_identifier) : null
   role_name                      = coalesce(each.value.role_name, "TFEPipeline${replace(title(each.key), "/[_-]/", "")}")
   sensitive_env_variables        = each.value.sensitive_env_variables

--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,7 @@ module "tfe_workspace" {
   team_access                    = var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
   terraform_version              = var.tfe_workspace.terraform_version
-  trigger_prefixes               = var.tfe_workspace.connect_vcs_repo != false ? var.tfe_workspace.trigger_prefixes : null
+  trigger_prefixes               = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.trigger_prefixes, ["modules"]) : null
   username                       = var.tfe_workspace.username
   working_directory              = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.working_directory, local.tfe_workspace.working_directory) : null
 }

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,7 @@ module "tfe_workspace" {
   project_id                     = var.tfe_workspace.project_id
   region                         = var.tfe_workspace.default_region
   remote_state_consumer_ids      = var.tfe_workspace.remote_state_consumer_ids
-  repository_identifier          = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.connect_vcs_repo, var.tfe_workspace.repository_identifier) : null
+  repository_identifier          = var.tfe_workspace.connect_vcs_repo ? var.tfe_workspace.repository_identifier : null
   role_name                      = var.tfe_workspace.role_name
   sensitive_env_variables        = var.tfe_workspace.sensitive_env_variables
   sensitive_hcl_variables        = var.tfe_workspace.sensitive_hcl_variables
@@ -130,10 +130,10 @@ module "additional_tfe_workspaces" {
   ssh_key_id                     = each.value.ssh_key_id != null ? each.value.ssh_key_id : var.tfe_workspace.ssh_key_id
   team_access                    = each.value.team_access != {} ? each.value.team_access : var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
-  terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.tfe_workspace.terraform_version
-  trigger_prefixes               = each.value.connect_vcs_repo != false ? each.value.trigger_prefixes : null
+  terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.additional_tfe_workspace.terraform_version
+  trigger_prefixes               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_prefixes, var.tfe_workspaces.trigger_prefixes) : null
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
-  working_directory              = each.value.connect_vcs_repo != false ? each.value.working_directory : "terraform/${coalesce(each.value.name, each.key)}"
+  working_directory              = each.value.connect_vcs_repo != false ? coalesce(each.value.working_directory, "terraform/${coalesce(each.value.name, each.key)}") : null
 }
 
 resource "aws_iam_account_alias" "alias" {

--- a/main.tf
+++ b/main.tf
@@ -63,15 +63,15 @@ module "tfe_workspace" {
   agent_role_arns                = var.tfe_workspace.agent_role_arns
   auth_method                    = var.tfe_workspace.auth_method
   auto_apply                     = var.tfe_workspace.auto_apply
-  branch                         = var.tfe_workspace.branch
+  branch                         = var.tfe_workspace.connect_vcs_repo ? var.tfe_workspace.branch : null
   clear_text_env_variables       = var.tfe_workspace.clear_text_env_variables
   clear_text_hcl_variables       = var.tfe_workspace.clear_text_hcl_variables
   clear_text_terraform_variables = merge(local.tfe_workspace.clear_text_terraform_variables, var.tfe_workspace.clear_text_terraform_variables)
   execution_mode                 = var.tfe_workspace.execution_mode
-  file_triggers_enabled          = var.tfe_workspace.file_triggers_enabled
+  file_triggers_enabled          = var.tfe_workspace.connect_vcs_repo != false ? var.tfe_workspace.file_triggers_enabled : null
   global_remote_state            = var.tfe_workspace.global_remote_state
   name                           = coalesce(var.tfe_workspace.name, var.name)
-  oauth_token_id                 = var.tfe_workspace.vcs_oauth_token_id
+  oauth_token_id                 = var.tfe_workspace.connect_vcs_repo != false ? var.tfe_workspace.vcs_oauth_token_id : null
   path                           = var.path
   permissions_boundary_arn       = try(aws_iam_policy.workspace_boundary[0].arn, null)
   policy                         = var.tfe_workspace.policy
@@ -90,9 +90,9 @@ module "tfe_workspace" {
   team_access                    = var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
   terraform_version              = var.tfe_workspace.terraform_version
-  trigger_prefixes               = var.tfe_workspace.trigger_prefixes
+  trigger_prefixes               = var.tfe_workspace.connect_vcs_repo != false ? var.tfe_workspace.trigger_prefixes : null
   username                       = var.tfe_workspace.username
-  working_directory              = var.tfe_workspace.working_directory != null ? var.tfe_workspace.working_directory : local.tfe_workspace.working_directory
+  working_directory              = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.working_directory, local.tfe_workspace.working_directory) : null
 }
 
 module "additional_tfe_workspaces" {
@@ -104,15 +104,15 @@ module "additional_tfe_workspaces" {
   agent_role_arns                = each.value.agent_role_arns != null ? each.value.agent_role_arns : var.tfe_workspace.agent_role_arns
   auth_method                    = each.value.auth_method != null ? each.value.auth_method : var.tfe_workspace.auth_method
   auto_apply                     = each.value.auto_apply
-  branch                         = coalesce(each.value.branch, var.tfe_workspace.branch)
+  branch                         = each.value.connect_vcs_repo != false ? coalesce(each.value.branch, var.tfe_workspace.branch) : null
   clear_text_env_variables       = each.value.clear_text_env_variables
   clear_text_hcl_variables       = each.value.clear_text_hcl_variables
   clear_text_terraform_variables = merge(local.tfe_workspace.clear_text_terraform_variables, each.value.clear_text_terraform_variables)
   execution_mode                 = coalesce(each.value.execution_mode, var.tfe_workspace.execution_mode)
-  file_triggers_enabled          = each.value.file_triggers_enabled
+  file_triggers_enabled          = each.value.connect_vcs_repo != false ? each.value.file_triggers_enabled : null
   global_remote_state            = each.value.global_remote_state
   name                           = coalesce(each.value.name, each.key)
-  oauth_token_id                 = coalesce(each.value.vcs_oauth_token_id, var.tfe_workspace.vcs_oauth_token_id)
+  oauth_token_id                 = each.value.connect_vcs_repo != false ? coalesce(each.value.vcs_oauth_token_id, var.tfe_workspace.vcs_oauth_token_id) : null
   path                           = var.path
   permissions_boundary_arn       = try(aws_iam_policy.workspace_boundary[0].arn, null)
   policy                         = each.value.policy
@@ -131,9 +131,9 @@ module "additional_tfe_workspaces" {
   team_access                    = each.value.team_access != {} ? each.value.team_access : var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
   terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.tfe_workspace.terraform_version
-  trigger_prefixes               = coalesce(each.value.trigger_prefixes, var.tfe_workspace.trigger_prefixes)
+  trigger_prefixes               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_prefixes, var.tfe_workspace.trigger_prefixes) : null
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
-  working_directory              = coalesce(each.value.working_directory, "terraform/${coalesce(each.value.name, each.key)}")
+  working_directory              = each.value.connect_vcs_repo != false ? each.value.working_directory : "terraform/${coalesce(each.value.name, each.key)}"
 }
 
 resource "aws_iam_account_alias" "alias" {

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ module "additional_tfe_workspaces" {
   team_access                    = each.value.team_access != {} ? each.value.team_access : var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
   terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.tfe_workspace.terraform_version
-  trigger_prefixes               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_prefixes, var.tfe_workspace.trigger_prefixes) : null
+  trigger_prefixes               = each.value.connect_vcs_repo != false ? each.value.trigger_prefixes : var.tfe_workspace.trigger_prefixes
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
   working_directory              = each.value.connect_vcs_repo != false ? each.value.working_directory : "terraform/${coalesce(each.value.name, each.key)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "tfe_workspace" {
     ssh_key_id                     = optional(string, null)
     organization                   = string
     terraform_version              = optional(string, null)
-    trigger_prefixes               = optional(list(string))
+    trigger_prefixes               = optional(list(string), ["modules"])
     username                       = optional(string, "TFEPipeline")
     vcs_oauth_token_id             = string
     working_directory              = optional(string, null)

--- a/variables.tf
+++ b/variables.tf
@@ -143,7 +143,7 @@ variable "tfe_workspace" {
     ssh_key_id                     = optional(string, null)
     organization                   = string
     terraform_version              = optional(string, null)
-    trigger_prefixes               = optional(list(string), ["modules"])
+    trigger_prefixes               = optional(list(string))
     username                       = optional(string, "TFEPipeline")
     vcs_oauth_token_id             = string
     working_directory              = optional(string, null)


### PR DESCRIPTION
This PR adds extra support for workspaces that don't use VCS repos. It puts some variables in the tfe_workspace and additional_tfe_workspaces in a if statement which sets the value to `null` when the connect_vcs_repo variable is set to false