### PR TITLE
fix: Setting `working_directory` shouldn't depend on a VCS connection

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ module "tfe_workspace" {
   terraform_version              = var.tfe_workspace.terraform_version
   trigger_prefixes               = var.tfe_workspace.connect_vcs_repo != false ? var.tfe_workspace.trigger_prefixes : null
   username                       = var.tfe_workspace.username
-  working_directory              = var.tfe_workspace.connect_vcs_repo != false ? coalesce(var.tfe_workspace.working_directory, local.tfe_workspace.working_directory) : null
+  working_directory              = coalesce(var.tfe_workspace.working_directory, local.tfe_workspace.working_directory)
   workspace_tags                 = var.tfe_workspace.workspace_tags
 }
 
@@ -202,6 +202,6 @@ module "additional_tfe_workspaces" {
   terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.tfe_workspace.terraform_version
   trigger_prefixes               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_prefixes, var.tfe_workspace.trigger_prefixes) : null
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
-  working_directory              = each.value.connect_vcs_repo != false ? coalesce(each.value.working_directory, "terraform/${coalesce(each.value.name, each.key)}") : null
+  working_directory              = coalesce(each.value.working_directory, "terraform/${coalesce(each.value.name, each.key)}")
   workspace_tags                 = each.value.workspace_tags
 }


### PR DESCRIPTION
Hi!

When not using the VCS connection (ie. when doing local development, but with remote run/state) you still need to specify the working_directory. Setting it to `null` when not having a VCS connection prevents a successful TF run.

Cheers,
Boris