### PR TITLE
breaking: generate the role from name if supplied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+#  Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# .tfvars files
+*.tfvars
+
+# CheckOv pre-commit external modules path
+**/.external_modules/*
+
+.terraform.lock.hcl

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 # UPGRADING
 
+## Upgrading to v6.0.0
+
+`v6.0.0` introduces a change that is not backwards compatible when the `name` property of `var.additional_tfe_workspaces` is specified and a different key is used in the provided map. Currently, the key is utilized to generate the role name, ignoring the specified `name` property. To correctly override the name field, it should also be used to create the `role_name`. To upgrade without any issues, ensure that the key matches the name in the provided `additional_tfe_workspaces`.
+
 ## Upgrading to v5.0.0
 
 `v5.0.0` is not backwards compatible with `v4.4.0` due to the deprecation of `tfe_workspace.trigger_prefixes` & `additional_tfe_workspaces.trigger_prefixes`.

--- a/main.tf
+++ b/main.tf
@@ -259,7 +259,7 @@ module "additional_tfe_workspaces" {
   region                         = each.value.default_region
   remote_state_consumer_ids      = each.value.remote_state_consumer_ids
   repository_identifier          = each.value.connect_vcs_repo != false ? coalesce(each.value.repository_identifier, var.tfe_workspace.repository_identifier) : null
-  role_name                      = coalesce(each.value.role_name, "TFEPipeline${replace(title(each.key), "/[_-]/", "")}")
+  role_name                      = coalesce(each.value.role_name, "TFEPipeline${replace(title(coalesce(each.value.name, each.key)), "/[_-]/", "")}")
   sensitive_env_variables        = each.value.sensitive_env_variables
   sensitive_hcl_variables        = each.value.sensitive_hcl_variables
   sensitive_terraform_variables  = each.value.sensitive_terraform_variables


### PR DESCRIPTION
If you supply a name you expect the role to be generate from the name field. Not the key.

People who use the name field and are not aware of this will have new roles created because of this fix.
