### PR TITLE
enhancement: bump aws-mcaf-workspace to 2.5.x

### DIFF
--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -17,5 +17,5 @@ terraform {
       version = ">= 4.0.4"
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.7.0"
 }

--- a/main.tf
+++ b/main.tf
@@ -176,7 +176,7 @@ module "tfe_workspace" {
   providers = { aws = aws.account }
 
   source  = "schubergphilis/mcaf-workspace/aws"
-  version = "~> 2.4.0"
+  version = "~> 2.5.0"
 
   agent_pool_id                  = var.tfe_workspace.agent_pool_id
   agent_role_arns                = var.tfe_workspace.agent_role_arns
@@ -228,7 +228,7 @@ module "additional_tfe_workspaces" {
   providers = { aws = aws.account }
 
   source  = "schubergphilis/mcaf-workspace/aws"
-  version = "~> 2.4.0"
+  version = "~> 2.5.0"
 
   agent_pool_id                  = each.value.agent_pool_id != null ? each.value.agent_pool_id : var.tfe_workspace.agent_pool_id
   agent_role_arns                = each.value.agent_role_arns != null ? each.value.agent_role_arns : var.tfe_workspace.agent_role_arns

--- a/terraform.tf
+++ b/terraform.tf
@@ -17,5 +17,5 @@ terraform {
       version = ">= 4.0.4"
     }
   }
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.7.0"
 }


### PR DESCRIPTION
bumps aws-mcaf-workspace to 2.5.x

increase required terraform version to >= 1.7.0 to align with a change in the dependency