### PR TITLE
enhancement: Ignore terraform_version when "" is provided in var.additional_tfe_workspaces.terraform_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ module "aws_account" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
 | <a name="requirement_mcaf"></a> [mcaf](#requirement\_mcaf) | >= 0.4.2 |
 | <a name="requirement_tfe"></a> [tfe](#requirement\_tfe) | >= 0.61.0 |
@@ -218,8 +218,8 @@ module "aws_account" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_account"></a> [account](#module\_account) | schubergphilis/mcaf-account/aws | ~> 0.5.1 |
-| <a name="module_additional_tfe_workspaces"></a> [additional\_tfe\_workspaces](#module\_additional\_tfe\_workspaces) | schubergphilis/mcaf-workspace/aws | ~> 2.4.0 |
-| <a name="module_tfe_workspace"></a> [tfe\_workspace](#module\_tfe\_workspace) | schubergphilis/mcaf-workspace/aws | ~> 2.4.0 |
+| <a name="module_additional_tfe_workspaces"></a> [additional\_tfe\_workspaces](#module\_additional\_tfe\_workspaces) | schubergphilis/mcaf-workspace/aws | ~> 2.5.0 |
+| <a name="module_tfe_workspace"></a> [tfe\_workspace](#module\_tfe\_workspace) | schubergphilis/mcaf-workspace/aws | ~> 2.5.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -267,7 +267,7 @@ module "additional_tfe_workspaces" {
   ssh_key_id                     = each.value.ssh_key_id != null ? each.value.ssh_key_id : var.tfe_workspace.ssh_key_id
   team_access                    = each.value.team_access != null ? each.value.team_access : var.tfe_workspace.team_access
   terraform_organization         = var.tfe_workspace.organization
-  terraform_version              = each.value.terraform_version != null ? each.value.terraform_version : var.tfe_workspace.terraform_version
+  terraform_version              = each.value.terraform_version != null ? (each.value.terraform_version == "" ? null : each.value.terraform_version) : var.tfe_workspace.terraform_version
   trigger_patterns               = each.value.connect_vcs_repo != false ? coalesce(each.value.trigger_patterns, var.tfe_workspace.trigger_patterns) : null
   username                       = coalesce(each.value.username, "TFEPipeline-${each.key}")
   variable_set_ids               = merge({ (local.account_variable_set.name) : tfe_variable_set.account.id }, each.value.variable_set_ids)


### PR DESCRIPTION
**:hammer_and_wrench: Summary**
<!--- A clear and concise description of what the PR entails. -->
Conditionally ignore Terraform version for existing workspaces. 

**:rocket: Motivation**
<!-- Why is this change required? What problem does it solve? -->
For workloads that manage their own Terraform version, you need to conditionally ignore the version by setting `var.additional_tfe_workspaces.terraform_version` to `""`.
