### PR TITLE
fix: Correct optional alias variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ module "account" {
 
 resource "aws_iam_account_alias" "alias" {
   provider      = aws.account
-  account_alias = "${var.account.alias_prefix}${var.name}"
+  account_alias = var.account.alias_prefix != null ? "${var.account.alias_prefix}${var.name}" : var.name
 }
 
 resource "aws_account_alternate_contact" "billing" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Correct the `account.alias_prefix` and `tfe_workspace.organisation` variables. Both were marked as optional but were not truly optional.

Fixed the `account.alias_prefix` handling if no value is given:

```
Error: Invalid template interpolation value
on .terraform/modules/xxx/main.tf line 63, in resource "aws_iam_account_alias" "alias":
  account_alias = "${var.account.alias_prefix}${var.name}"
var.account.alias_prefix is null
The expression result is null. Cannot include a null value in a string template.
```

