### PR TITLE
fix: project variable set is not attached to workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ module "aws_account" {
 | <a name="module_account"></a> [account](#module\_account) | schubergphilis/mcaf-account/aws | ~> 0.5.1 |
 | <a name="module_additional_tfe_workspaces"></a> [additional\_tfe\_workspaces](#module\_additional\_tfe\_workspaces) | schubergphilis/mcaf-workspace/aws | ~> 4.0.0 |
 | <a name="module_tfe_project_auth"></a> [tfe\_project\_auth](#module\_tfe\_project\_auth) | schubergphilis/mcaf-workspace/aws//modules/auth | ~> 3.1.0 |
-| <a name="module_tfe_project_variable_set"></a> [tfe\_project\_variable\_set](#module\_tfe\_project\_variable\_set) | schubergphilis/mcaf-variable-set/tfe | ~> 0.1.0 |
+| <a name="module_tfe_project_variable_set"></a> [tfe\_project\_variable\_set](#module\_tfe\_project\_variable\_set) | schubergphilis/mcaf-variable-set/tfe | ~> 0.2.0 |
 | <a name="module_tfe_workspace"></a> [tfe\_workspace](#module\_tfe\_workspace) | schubergphilis/mcaf-workspace/aws | ~> 4.0.0 |
 
 ## Resources
@@ -265,7 +265,6 @@ module "aws_account" {
 | [aws_iam_policy.workspace_boundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [tfe_project.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/project) | resource |
 | [tfe_project_settings.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/project_settings) | resource |
-| [tfe_project_variable_set.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/project_variable_set) | resource |
 | [tfe_variable.account_variable_set_clear_text_env_variables](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable.account_variable_set_clear_text_hcl_variables](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable.account_variable_set_clear_text_terraform_variables](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ module "aws_account" {
 | [aws_iam_policy.workspace_boundary](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [tfe_project.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/project) | resource |
 | [tfe_project_settings.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/project_settings) | resource |
+| [tfe_project_variable_set.default](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/project_variable_set) | resource |
 | [tfe_variable.account_variable_set_clear_text_env_variables](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable.account_variable_set_clear_text_hcl_variables](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |
 | [tfe_variable.account_variable_set_clear_text_terraform_variables](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs/resources/variable) | resource |

--- a/main.tf
+++ b/main.tf
@@ -229,6 +229,13 @@ module "tfe_project_variable_set" {
   )
 }
 
+resource "tfe_project_variable_set" "default" {
+  count = var.tfe_project.enabled && (var.tfe_project.variable_set != null || try(var.tfe_project.auth.enabled, false)) ? 1 : 0
+
+  variable_set_id = module.tfe_project_variable_set[0].id
+  project_id      = tfe_project.default[0].id
+}
+
 module "tfe_project_auth" {
   count = var.tfe_project.enabled && try(var.tfe_project.auth.enabled, false) ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -188,7 +188,7 @@ module "tfe_project_variable_set" {
   count = var.tfe_project.enabled && (var.tfe_project.variable_set != null || try(var.tfe_project.auth.enabled, false)) ? 1 : 0
 
   source  = "schubergphilis/mcaf-variable-set/tfe"
-  version = "~> 0.1.0"
+  version = "~> 0.2.0"
 
   name              = "project-${local.tfe_project_name}"
   description       = "Variable set for the ${local.tfe_project_name} project"
@@ -227,13 +227,6 @@ module "tfe_project_variable_set" {
       }
     }
   )
-}
-
-resource "tfe_project_variable_set" "default" {
-  count = var.tfe_project.enabled && (var.tfe_project.variable_set != null || try(var.tfe_project.auth.enabled, false)) ? 1 : 0
-
-  variable_set_id = module.tfe_project_variable_set[0].id
-  project_id      = tfe_project.default[0].id
 }
 
 module "tfe_project_auth" {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

In the current version the created project variable set is owned by project but not automatically attached to it's workspaces. This PR fixes that.

## :rocket: Motivation

Project-scoped authentication is not working if the project variable set is not attached to workspaces.

## :pencil: Additional Information

n/a
